### PR TITLE
Relative dataUrl

### DIFF
--- a/assets/js/tsne-webgl.js
+++ b/assets/js/tsne-webgl.js
@@ -7,7 +7,7 @@ var imageData = {};
 var imageDataKeys = [];
 
 // Identify data endpoint
-var dataUrl = 'http://localhost:5000/output/';
+var dataUrl = 'output/';
 
 // Create global stores for image and atlas sizes
 var sizes = {


### PR DESCRIPTION
making the dataUrl relative means that the generated files can be deployed to any path on a webserver, without having to adjust anything.