### PR TITLE
Switch to splitext instead of split to handle filenames with multiple dots

### DIFF
--- a/utils/process_images.py
+++ b/utils/process_images.py
@@ -240,7 +240,7 @@ class PixPlot:
         width, height = image.size
       # Add the image name, x offset, y offset
       image_positions.append([
-        os.path.basename(img).split('.')[0],
+        os.path.splitext(os.path.basename(img))[0],
         int(i[0] * 100),
         int(i[1] * 100),
         width,


### PR DESCRIPTION
See https://stackoverflow.com/questions/678236/how-to-get-the-filename-without-the-extension-from-a-path-in-python for discussion.