### PR TITLE
utf-8 as filename encoding for montage

### DIFF
--- a/utils/process_images.py
+++ b/utils/process_images.py
@@ -15,6 +15,7 @@ import glob, json, os, re, sys, tarfile, psutil, subprocess
 import tensorflow as tf
 import numpy as np
 import argparse
+import codecs
 
 # tensorflow config
 FLAGS = tf.app.flags.FLAGS
@@ -60,6 +61,7 @@ class PixPlot:
     self.create_atlas_files()
     print('Finished generating PixPlot structure for ' + str(len(self.image_files)) + ' images')
 
+
   def validate_inputs(self):
     '''
     Make sure the inputs are valid, and warn users if they're not
@@ -85,6 +87,7 @@ class PixPlot:
       print(message)
       sys.exit()
 
+      
   def create_output_dirs(self):
     '''
     Create each of the required output dirs
@@ -355,8 +358,9 @@ class PixPlot:
 
       # write a file containing a list of images for the current montage
       tmp_file_path = join(self.output_dir, 'images_to_montage.txt')
-      with open(tmp_file_path, 'w') as out:
-        out.write('\n'.join(map('"{0}"'.format, atlas_images)))
+      # The encoding/decode is needed to support non-ASCII characters in filenames
+      with codecs.open(tmp_file_path, 'w', encoding='utf-8') as out:
+        out.write('\n'.join(map('"{0}"'.decode('utf-8').format, atlas_images)))
 
       # build the imagemagick command to montage the images
       cmd =  'montage @' + tmp_file_path + ' '


### PR DESCRIPTION
Having non-ASCII characters makes PixPlot throw an exception when generating the atlas files. Encoding filename characters > 127 fixes this.

I chose `utf-8` as encoding, but strictly speaking this is a hack as the _byte_-representation of the input filenames should be used instead, to make the script fully file system name encoding scheme independent. But working with filenames as bytes instead of strings is a pain. `utf-8` is a true superset of ASCII so this pull request does not break anything and helps those that uses `utf-8` as filename encoding.