### PR TITLE
Store cluster membership

### DIFF
--- a/utils/process_images.py
+++ b/utils/process_images.py
@@ -263,27 +263,36 @@ class PixPlot:
       ])
     return image_positions
 
+  def build_clustering(self):
+    '''
+    Use KMeans clustering to find n centroids
+    '''
+    print(' * calculating ' + str(self.n_clusters) + ' clusters')
+    model = KMeans(n_clusters=self.n_clusters)
+    X = np.array(self.image_vectors)
+    fit_model = model.fit(X)
+    self.clustering = fit_model
+
 
   def get_centroids(self):
     '''
     Use KMeans clustering to find n centroid images
     that represent the center of an image cluster
     '''
-    print(' * calculating ' + str(self.n_clusters) + ' clusters')
-    model = KMeans(n_clusters=self.n_clusters)
+    self.build_clustering()
+    centroids = self.clustering.cluster_centers_
+    labels = self.clustering.labels_
     X = np.array(self.image_vectors)
-    fit_model = model.fit(X)
-    centroids = fit_model.cluster_centers_
     # find the points closest to the cluster centroids
     closest, _ = pairwise_distances_argmin_min(centroids, X)
     centroid_paths = [self.vector_files[i] for i in closest]
     centroid_json = []
     for c, i in enumerate(centroid_paths):
-      print([item for item, label in enumerate(fit_model.labels_) if label == c])
+      print([item for item, label in enumerate(labels) if label == c])
       centroid_json.append({
         'img': get_filename(i),
         'label': 'Cluster ' + str(c+1),
-        'members': [item for item, label in enumerate(fit_model.labels_) if label == c]
+        'members': [item for item, label in enumerate(labels) if label == c]
       })
     return centroid_json
 

--- a/utils/process_images.py
+++ b/utils/process_images.py
@@ -254,19 +254,21 @@ class PixPlot:
       thumb_path = join(self.output_dir, 'thumbs', '32px', img)
       with Image.open(thumb_path) as image:
         width, height = image.size
-      # Add the image name, x offset, y offset
+      cluster = int(self.clustering.labels_[c]) + 1 # Because PixPlot.get_centroids() names them from 1 onwards
+      # Add the image name, x offset, y offset, cluster
       image_positions.append([
         os.path.splitext(os.path.basename(img))[0],
         int(i[0] * 100),
         int(i[1] * 100),
         width,
-        height
+        height,
+        cluster
       ])
     return image_positions
 
   def build_clustering(self):
     '''
-    Use KMeans clustering to find n centroids
+    Use KMeans clustering to find n centroids.
     '''
     print(' * calculating ' + str(self.n_clusters) + ' clusters')
     model = KMeans(n_clusters=self.n_clusters)
@@ -277,8 +279,7 @@ class PixPlot:
 
   def get_centroids(self):
     '''
-    Use KMeans clustering to find n centroid images
-    that represent the center of an image cluster
+    Find n centroid images that represent the center of an image cluster
     '''
     centroids = self.clustering.cluster_centers_
     labels = self.clustering.labels_

--- a/utils/process_images.py
+++ b/utils/process_images.py
@@ -68,6 +68,7 @@ class PixPlot:
     self.create_image_thumbs()
     self.create_image_vectors()
     self.load_image_vectors()
+    self.build_clustering()
     self.write_json()
     self.create_atlas_files()
     print('Processed output for ' + \
@@ -279,7 +280,6 @@ class PixPlot:
     Use KMeans clustering to find n centroid images
     that represent the center of an image cluster
     '''
-    self.build_clustering()
     centroids = self.clustering.cluster_centers_
     labels = self.clustering.labels_
     X = np.array(self.image_vectors)
@@ -288,7 +288,6 @@ class PixPlot:
     centroid_paths = [self.vector_files[i] for i in closest]
     centroid_json = []
     for c, i in enumerate(centroid_paths):
-      print([item for item, label in enumerate(labels) if label == c])
       centroid_json.append({
         'img': get_filename(i),
         'label': 'Cluster ' + str(c+1),

--- a/utils/process_images.py
+++ b/utils/process_images.py
@@ -279,9 +279,11 @@ class PixPlot:
     centroid_paths = [self.vector_files[i] for i in closest]
     centroid_json = []
     for c, i in enumerate(centroid_paths):
+      print([item for item, label in enumerate(fit_model.labels_) if label == c])
       centroid_json.append({
         'img': get_filename(i),
-        'label': 'Cluster ' + str(c+1)
+        'label': 'Cluster ' + str(c+1),
+        'members': [item for item, label in enumerate(fit_model.labels_) if label == c]
       })
     return centroid_json
 


### PR DESCRIPTION
Ok amends the _plot_data.json_ file with _k_-means clustering. The status quo master branch calculates a clustering to select hotspot images for human consuption on the web UI. With this both the membership for the centroids as `centroids/members`, as well as the labels are retained as the fifth list element for each of the images under `positions` in the output file.

So from

```json
{
    "centroids" : [
	{
            "label" : "Cluster 1",
            "img" : "img_021_Brazil_pt_global_warming.jpg"
	},
	{
            "label" : "Cluster 2",
            "img" : "img_125_Brazil_pt_global_warming.jpg",
	}
    ],
   "positions" : [
      ["img_124_Brazil_pt_climate_change_mitigation", -785, 740, 32, 24],
      ["img_078_Brazil_pt_climate_change", -456, -94, 32, 22],
      ["img_022_Brazil_pt_global_warming", -380, 349, 32, 26],
      ["img_219_Brazil_pt_climate_change_adaptation", -735, 746, 32, 24]
    ]
}
```

To

```json
{
    "centroids" : [
	{
            "label" : "Cluster 1",
            "img" : "img_021_Brazil_pt_global_warming.jpg",
            "members" : [89, 124, 297, 312, 440]
	},
	{
            "label" : "Cluster 2",
            "img" : "img_125_Brazil_pt_global_warming.jpg",
            "members" : [13, 40, 51, 55, 81, 83, 109, 191]
	}
    ],
   "positions" : [
      ["img_124_Brazil_pt_climate_change_mitigation", -785, 740, 32, 24, 1],
      ["img_078_Brazil_pt_climate_change", -456, -94, 32, 22, 2],
      ["img_022_Brazil_pt_global_warming", -380, 349, 32, 26, 2],
      ["img_219_Brazil_pt_climate_change_adaptation", -735, 746, 32, 24, 1]
    ]
}
```
You get the idea, I hope.

Here's a colouring, with _k_=20, produced outside of the web UI.

![Brazil k-means clustering with k=20](https://user-images.githubusercontent.com/879300/60731576-3197bb80-9f48-11e9-97fa-d34f9d17cfa3.png)

The solution needs validation. From let's say engineering and software design point and it would be nice to confidently say this PR doesn't break anything, e.g. the JSON file parsing by the visualization data load or something. From design or research tooling point of view it is worth asking whether making available a discrete cluster membership is a good idea for working forward from the _plot_data.json_, because it is a certain violence done on the more topological, much continuous space which we are working with here.

Closes #74.