### PR TITLE
Add touch-action

### DIFF
--- a/pixplot/web/assets/css/style.css
+++ b/pixplot/web/assets/css/style.css
@@ -21,6 +21,7 @@ canvas {
 body,
 html {
   background: #111;
+  touch-action: none;
 }
 
 a {


### PR DESCRIPTION
If you load PixPlot on a touch device, it doesn't handle the pinch/spread gesture correctly. The browser interprets the pinch/spread as a UI zoom command, which scales up/down the entire interface, equivalent to hitting `Ctrl +/-`on a Windows machine. With the inclusion of the `touch-action` property, the browser will ignore touch events, thus letting the individual elements handle the events on their own. UI elements will ignore the pinch/spread event, but the `TrackballControls` will catch and handle it properly as a zoom within the three.js scene.