### PR TITLE
pretty-print json output

### DIFF
--- a/pixplot/pixplot.py
+++ b/pixplot/pixplot.py
@@ -833,11 +833,11 @@ def write_json(path, obj, **kwargs):
   if not os.path.exists(out_dir): os.makedirs(out_dir)
   if kwargs.get('gzip', False):
     with gzip.GzipFile(path, 'w') as out:
-      out.write(json.dumps(obj).encode(kwargs['encoding']))
+      out.write(json.dumps(obj, indent=4).encode(kwargs['encoding']))
     return path
   else:
     with open(path, 'w') as out:
-      json.dump(obj, out)
+      json.dump(obj, out, indent=4)
     return path
 
 


### PR DESCRIPTION
This is really only useful for the centroid files, I think, to make curation easier. Perhaps conditionalize?  Regardless, I've tested with both the gzip and non-gzip cases...