### PR TITLE
Handle Windows paths and add matplotlib to requirements

### DIFF
--- a/pixplot/web/assets/js/tsne.js
+++ b/pixplot/web/assets/js/tsne.js
@@ -3591,7 +3591,7 @@ function getCanvasSize() {
 function getPath(path) {
   var base = window.location.origin;
   base += window.location.pathname.replace('index.html', '');
-  base += path.replace('output/', '');
+  base += path.replace('\\','/').replace('output/', '');
   return base;
 }
 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
     'umap-learn==0.4.0',
     'yale-dhlab-rasterfairy>=1.0.3',
     'yale-dhlab-keras-preprocessing>=1.1.1',
+    'matplotlib'
   ],
   entry_points={
     'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ for i in dirs:
   for root, subdirs, files in os.walk(i):
     if not files: continue
     for file in files:
-      web.append(join(root.replace('pixplot/', ''), file))
+      web.append(join(root.replace('pixplot/', '').replace('pixplot\\',''), file))
 
 setup(
   name='pixplot',


### PR DESCRIPTION
This PR has two changes to handle Windows paths:
- "Replace backslashes in paths" handles backslashes in `manifest.json`, which result in a 404 error when loading `index.html`.
- "Handle pixplot folder" takes care of the web assets to be copied by `setup.py`. This should solve Issue #132 .

In a separate commit, it also adds `matplotlib` to the requirements in setup.py

Please let me know if there's anything I can do to make this more useful -- not sure if it's okay to have three commits in the PR.