### PR TITLE
bump tf version to 2.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     'scikit-learn==0.24.2',
     'scipy==1.4.0',
     'six==1.15.0',
-    'tensorflow==2.4.0',
+    'tensorflow==2.5.0',
     'tqdm==4.61.1',
     'umap-learn==0.5.1',
     'yale-dhlab-rasterfairy>=1.0.3',


### PR DESCRIPTION
I think if we advance tensorflow to 2.5, we can get around a problem where 2.4 is looking for cuda 10-era libraries (https://github.com/tensorflow/tensorflow/issues/44777#issuecomment-813919887).  There are hacks to work around this, but they involve symlinking  the cuda 11 libraries to masquerade as older versions.  I've tested tf2.5 on a clean virtual environment and it seems to work fine.