### PR TITLE
bump h5py version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     'cmake>=3.15.3',
     'Cython>=0.29.21',
     'glob2>=0.6',
-    'h5py~=2.10.0',
+    'h5py~=3.1.0',
     'iiif-downloader>=0.0.6',
     'numba==0.53',
     'numpy==1.19.5',


### PR DESCRIPTION
Build with tf 2.5 fails unless h5py version is higher
ref: #234 

> ERROR: Cannot install pixplot and pixplot==0.0.113 because these package versions have conflicting dependencies.
> 
> The conflict is caused by:
>     pixplot 0.0.113 depends on h5py~=2.10.0
>     tensorflow 2.5.0 depends on h5py~=3.1.0