### PR TITLE
Bug 270

### DIFF
--- a/pixplot/pixplot.py
+++ b/pixplot/pixplot.py
@@ -200,7 +200,7 @@ def filter_images(**kwargs):
     filename = clean_filename(i.path)
     if filename in image_paths:
       duplicates.add(filename)
-    image_paths.add(filename)
+    image_paths.add(i.path)
   if duplicates:
     raise Exception('''
       Image filenames should be unique, but the following filenames are duplicated\n

--- a/pixplot/pixplot.py
+++ b/pixplot/pixplot.py
@@ -194,13 +194,10 @@ def copy_web_assets(**kwargs):
 def filter_images(**kwargs):
   '''Main method for filtering images given user metadata (if provided)'''
   # validate that input image names are unique
-  image_paths = set()
-  duplicates = set()
-  for i in stream_images(image_paths=get_image_paths(**kwargs)):
-    filename = clean_filename(i.path)
-    if filename in image_paths:
-      duplicates.add(filename)
-    image_paths.add(i.path)
+  image_paths = set(get_image_paths(images=kwargs["images"], out_dir=kwargs["out_dir"]))
+  image_names = list(map(clean_filename,image_paths))
+  duplicates = set([x for x in image_names if image_names.count(x) > 1])
+
   if duplicates:
     raise Exception('''
       Image filenames should be unique, but the following filenames are duplicated\n

--- a/pixplot/pixplot.py
+++ b/pixplot/pixplot.py
@@ -197,9 +197,10 @@ def filter_images(**kwargs):
   image_paths = set()
   duplicates = set()
   for i in stream_images(image_paths=get_image_paths(**kwargs)):
-    if i.path in image_paths:
-      duplicates.add(i.path)
-    image_paths.add(i.path)
+    filename = clean_filename(i.path)
+    if filename in image_paths:
+      duplicates.add(filename)
+    image_paths.add(filename)
   if duplicates:
     raise Exception('''
       Image filenames should be unique, but the following filenames are duplicated\n


### PR DESCRIPTION
Fix for issue #270 (Improper duplicate name validation in filter_images())


Modified filter_images function
https://github.com/YaleDHLab/pix-plot/blob/48c8e6b3732ada3291ee2f6ebffce934fe4faee2/pixplot/pixplot.py#L196

Validation will only compare the basename, instead of the path, when looking for duplicates.



